### PR TITLE
Fix selecting resources from different contexts

### DIFF
--- a/core/components/calltoactiontv/processors/resource/getlist.class.php
+++ b/core/components/calltoactiontv/processors/resource/getlist.class.php
@@ -58,7 +58,7 @@ class callToActionTVResourceGetListProcessor extends modObjectGetListProcessor
             if ($this->tvObject && !empty(trim($this->tvObject->get('elements')))) {
                 $options = [];
 
-                foreach (explode('||', $this->tvObject->processBindings($this->tvObject->get('elements'))) as $item) {
+                foreach (explode('||', $this->tvObject->processBindings($this->tvObject->get('elements'), $this->getProperty('resourceId'))) as $item) {
                     list($pagetitle, $id) = explode('==', $item);
 
                     $options[] = [


### PR DESCRIPTION
core\model\modx\modtemplatevar.class.php
line 771
    public function processBindings($value= '', $**resourceId**= 0, $preProcess = true) {

We should send resource ID because otherwise we will laways get WEB context 